### PR TITLE
feat(SlevomatCodingStandard.Functions.StaticClosure): enable again outside tests

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -200,7 +200,9 @@
     <exclude name="SlevomatCodingStandard.Files.FilepathNamespaceExtractor" />
 
     <!-- ========================= Functions rules ========================== -->
-    <exclude name="SlevomatCodingStandard.Functions.StaticClosure" />
+    <rule ref="SlevomatCodingStandard.Functions.StaticClosure">
+        <exclude-pattern>tests/*</exclude-pattern>
+    </rule>
     <rule ref="SlevomatCodingStandard.Functions.ArrowFunctionDeclaration" />
     <rule ref="SlevomatCodingStandard.Functions.DisallowEmptyFunction" />
     <rule ref="SlevomatCodingStandard.Functions.FunctionLength">


### PR DESCRIPTION
## Summary

- Re-enables `SlevomatCodingStandard.Functions.StaticClosure` rule for non-test PHP code
- Excludes the rule from `tests/*` directory because PEST framework does not support static closures
- Replaces the global `<exclude>` with a `<rule>` + `<exclude-pattern>` configuration

## Changes

The rule was previously fully excluded from the entire codebase. Now it is active for all production code while tests remain exempt.

```xml
<!-- Before -->
<exclude name="SlevomatCodingStandard.Functions.StaticClosure" />

<!-- After -->
<rule ref="SlevomatCodingStandard.Functions.StaticClosure">
    <exclude-pattern>tests/*</exclude-pattern>
</rule>
```

## Test plan

- [x] All 10 existing tests pass
- [x] PHPCS checks pass (`composer check`)
- [x] Rector fixers run clean (`composer fix`)

Closes https://github.com/pekral/phpcs-rules/issues/56

🤖 Generated with [Claude Code](https://claude.com/claude-code)